### PR TITLE
add upgrade crd tools

### DIFF
--- a/deploy/helm/rbgs/templates/upgrade/crd-upgrade.yaml
+++ b/deploy/helm/rbgs/templates/upgrade/crd-upgrade.yaml
@@ -1,0 +1,67 @@
+{{ if .Values.crdUpgrade.enabled -}}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: rbgs-crds-upgrade-{{ replace "." "" .Chart.AppVersion }}
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "-4"
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+{{- if .Values.crdUpgrade.ttlSecondsAfterFinished }}
+  ttlSecondsAfterFinished: {{ .Values.crdUpgrade.ttlSecondsAfterFinished }}
+{{- end }}
+  template:
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: rbgs-crds-upgrade
+      containers:
+        - name: rbgs-crds-upgrade
+          image: "{{ .Values.crdUpgrade.repository }}:{{ .Values.crdUpgrade.imageTag | default .Chart.AppVersion }}"
+      restartPolicy: OnFailure
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: rbgs-crds-upgrade
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
+rules:
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["create", "get", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: rbgs-crds-upgrade
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: rbgs-crds-upgrade
+subjects:
+  - kind: ServiceAccount
+    name: rbgs-crds-upgrade
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rbgs-crds-upgrade
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
+{{- end }}

--- a/deploy/helm/rbgs/values.yaml
+++ b/deploy/helm/rbgs/values.yaml
@@ -34,3 +34,11 @@ nodeSelector: {}
 
 tolerations: []
 
+crdUpgrade:
+  enabled: true
+  # This sets the time-to-live (TTL) for crd-upgrade jobs. Default is 259200 seconds (3 days).
+  ttlSecondsAfterFinished: 259200
+  repository: registry-cn-hangzhou.ack.aliyuncs.com/dev/rbgs-upgrade-crd
+  imageTag: v0.3.0-upgrade-crd
+
+

--- a/tools/crd-upgrade/Dockerfile
+++ b/tools/crd-upgrade/Dockerfile
@@ -1,0 +1,15 @@
+FROM registry-cn-hangzhou.ack.aliyuncs.com/dev/alpine:3.18-update
+
+COPY ./deploy/helm/rbgs/crds /rbgs/crds
+COPY ./tools/crd-upgrade/upgrade-crds.sh /rbgs/upgrade-crds.sh
+
+RUN apk add --update bash curl iproute2 libc6-compat tzdata vim &&  \
+ 	rm -rf /var/cache/apk/* && \
+ 	cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && \
+ 	echo "Asia/Shanghai" >  /etc/timezone
+
+# need kubectl as upgrade-crds.sh uses it.
+ARG TARGETARCH
+RUN curl -L -o /usr/local/bin/kubectl "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/${TARGETARCH}/kubectl" && chmod +x /usr/local/bin/kubectl
+
+ENTRYPOINT ["bash","/rbgs/upgrade-crds.sh"]

--- a/tools/crd-upgrade/upgrade-crds.sh
+++ b/tools/crd-upgrade/upgrade-crds.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+for crdfile in $(find /rbgs/crds/*.yaml);
+do
+  crdshort=${crdfile#*_}
+  if [[ $(kubectl get --ignore-not-found -f $crdfile | wc -l) -gt 0 ]]; then
+    echo "$crdshort founded, replacing its crd..."
+    kubectl replace -f $crdfile
+  else
+    echo "$crdshort not founded, applying its crd..."
+    kubectl create -f $crdfile
+  fi
+done


### PR DESCRIPTION
add a tool to support update helm crd

Helm upgrade can not update crd according to [Helm doc](https://helm.sh/docs/chart_best_practices/custom_resource_definitions/). So we add hook job to install/update crd